### PR TITLE
Add python_requires to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -78,6 +78,7 @@ setup(
     ],
     url="https://stackstorm.github.io/PySwitchLib/",
     include_package_data=True,
+    python_requires='>=2.7,<3.0',
     install_requires=reqs,
     cmdclass={
         'install': PostInstallCommand,


### PR DESCRIPTION
This project relies on version 4.62 of `Pyro4`, which [does not pin its dependency of `serpent` to any particular version](https://github.com/irmen/Pyro4/blob/8ecd97ab38c41d175bb149af0bde632b417af463/setup.py#L53). However, the latest versions of `serpent` [remove Python 2 support](https://github.com/irmen/Serpent/blob/60877b581069d4e592531968edd6c1468c822b0a/setup.py#L183), so this breaks installation of this package, as well as downstream packages like [stackstorm-network_essentials](https://circleci.com/gh/StackStorm-Exchange/stackstorm-network_essentials/258).

This PR adds the `python_requires` specifier to `setup.py` to instruct pip (`>=9`) and setuptools (`>=42`) to only consider dependency versions that support Python 2.

More information on `python_requires` can be found here:
https://packaging.python.org/guides/dropping-older-python-versions/#specify-the-version-ranges-for-supported-python-distributions